### PR TITLE
Fix URL path

### DIFF
--- a/Casks/radiola.rb
+++ b/Casks/radiola.rb
@@ -2,7 +2,7 @@ cask "radiola" do
   version "7.0.2"
   sha256 "834d07f0e55ea874e1270284745123c3d6b312a2618ed5235fb0d5290f8f31e9"
 
-  url "https://github.com/SokoloffA/radiola/releases/download/v#{version.major_minor}/Radiola-#{version}.dmg"
+  url "https://github.com/SokoloffA/radiola/releases/download/v#{version}/Radiola-#{version}.dmg"
   # NOTE: When a GitHub release tag is in MAJOR.MINOR.PATCH format, use
   # url "https://github.com/SokoloffA/radiola/releases/download/v#{version}/Radiola-#{version}.dmg"
   # NOTE: When a GitHub release tag is in MAJOR.MINOR format, use


### PR DESCRIPTION
> Error: sokoloffa/radiola/radiola: Download failed on Cask 'radiola' with message: Download failed: https://github.com/SokoloffA/radiola/releases/download/v7.0/Radiola-7.0.2.dmg

Sorry, I broke it or something changed about the structure of the release tags. This PR should fix it.

Thanks for developing Radiola!